### PR TITLE
Debug Wine Recommendation Tap Interaction Issue

### DIFF
--- a/ViewModels/WineCellarQueryViewModel.swift
+++ b/ViewModels/WineCellarQueryViewModel.swift
@@ -76,4 +76,14 @@ class WineCellarQueryViewModel: ObservableObject {
         pairingType = .food
         selectedWineColor = nil
     }
+
+    func updateWine(_ wine: Wine) async {
+        do {
+            try repository.saveWine(wine)
+            // Update the matched wine to reflect the changes
+            matchedWine = wine
+        } catch {
+            print("Error updating wine: \(error)")
+        }
+    }
 }

--- a/Views/WineCellarQueryView.swift
+++ b/Views/WineCellarQueryView.swift
@@ -49,7 +49,11 @@ struct WineCellarQueryView: View {
                                 
                                 Group {
                                     if let matchedWine = viewModel.matchedWine {
-                                        NavigationLink(destination: WineDetailView(wine: matchedWine, onUpdate: { _ in })) {
+                                        NavigationLink(destination: WineDetailView(wine: matchedWine, onUpdate: { updatedWine in
+                                            Task {
+                                                await viewModel.updateWine(updatedWine)
+                                            }
+                                        })) {
                                             wineCardContent(recommendation: recommendation, matchedWine: matchedWine)
                                         }
                                         .buttonStyle(PlainButtonStyle())


### PR DESCRIPTION
Previously, when editing a wine from the recommendation/sommelier view, changes were lost because the onUpdate callback was empty. This caused issues like photos vanishing after editing.

Changes:
- Added updateWine() method to WineCellarQueryViewModel to save wine updates
- Updated NavigationLink in WineCellarQueryView to call updateWine() properly
- Wine edits from recommendation view now persist to database correctly

This ensures consistent behavior between editing from inventory vs recommendation views.